### PR TITLE
Add node modules to excluded files in Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,3 +29,5 @@ gems:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - package.json
+  - node_modules


### PR DESCRIPTION
Currently, this site is publishing its node modules directory during Federalist builds. This commit adds the `node_modules` directory and the `package.json` to the `exclude` list in the Jekyll configuration. This will prevent those files from being built into the site in the future.

Ref 18f/federalist#735